### PR TITLE
Add support for deboost in queries

### DIFF
--- a/src/main/scala/Engine.scala
+++ b/src/main/scala/Engine.scala
@@ -53,7 +53,8 @@ case class Field( // no optional values for fields, whne specified
   name: String, // name of metadata field
   values: Seq[String], // fields can have multiple values like tags of a single value as when using hierarchical
   // taxonomies
-  bias: Float) // any positive value is a boost, negative is a filter
+  bias: Float,  // any positive value is a boost, negative is a filter
+  mode: Option[String]) //None or boost : boost, debost : deboost) 
     extends Serializable
 
 /** Used to specify the date range for a query */

--- a/src/main/scala/URAlgorithm.scala
+++ b/src/main/scala/URAlgorithm.scala
@@ -23,7 +23,7 @@ import grizzled.slf4j.Logger
 import org.apache.predictionio.controller.{ P2LAlgorithm, Params }
 import org.apache.predictionio.data.storage.{ DataMap, Event, NullModel, PropertyMap }
 import org.apache.predictionio.data.store.LEventStore
-import org.apache.mahout.math.cf.{DownsamplableCrossOccurrenceDataset, SimilarityAnalysis}
+import org.apache.mahout.math.cf.{ DownsamplableCrossOccurrenceDataset, SimilarityAnalysis }
 import org.apache.mahout.sparkbindings.indexeddataset.IndexedDatasetSpark
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
@@ -624,6 +624,13 @@ class URAlgorithm(val ap: URAlgorithmParams)
         render("terms" -> (actionName -> itemIDs) ~ ("boost" -> boost))
     }
 
+    val deBoostedMetadata = getDeboostedMetadata(query)
+    val deboostFields : Seq[JValue] = deBoostedMetadata.map {
+      case BoostableCorrelators(actionName, itemIDs, boost) =>
+        render("bool" -> ("must_not" -> ("terms" -> (actionName -> itemIDs))) ~ ("boost" -> boost))
+    }
+    val shouldFieldWithDeboosts: Seq[JValue] = shouldFields ++ deboostFields
+
     // todo: this should not be sent if there are no rankings, causes 0 scores to be returned as backfill even
     // with no other ranking. Currently the 0 score results are filtered out for no active ranking.
     val shouldScore: JValue = parse(
@@ -637,8 +644,7 @@ class URAlgorithm(val ap: URAlgorithmParams)
         |  }
         |}
         |""".stripMargin)
-
-    shouldFields :+ shouldScore
+     shouldFieldWithDeboosts :+ shouldScore
   }
 
   /** Build must query part */
@@ -681,7 +687,7 @@ class URAlgorithm(val ap: URAlgorithmParams)
     // then get the properties used in must_not clause
     val exclusionFields = query.fields.getOrElse(Seq.empty).filter(_.bias == 0)
     val exclusionProperties: Seq[JValue] = exclusionFields.map {
-      case Field(name, value, bias) =>
+      case Field(name, value, bias, mode) =>
         render(
           "terms" ->
             (name -> value) ~
@@ -813,9 +819,17 @@ class URAlgorithm(val ap: URAlgorithmParams)
   /** get all metadata fields that potentially have boosts (not filters) */
   def getBoostedMetadata(query: Query): Seq[BoostableCorrelators] = {
     val paramsBoostedFields = fields.filter(_.bias < 0f)
-    val queryBoostedFields = query.fields.getOrEmpty.filter(_.bias > 0f)
+    val queryBoostedFields = query.fields.getOrEmpty.filter(_.bias > 0f).filter(x => !x.mode.isDefined || x.mode == Some("boost") )
 
     (queryBoostedFields ++ paramsBoostedFields)
+      .map(field => BoostableCorrelators(field.name, field.values, Some(field.bias)))
+      .distinct // de-dup and favor query fields
+  }
+
+  def getDeboostedMetadata(query: Query): Seq[BoostableCorrelators] = {
+    val queryDeBoostedFields = query.fields.getOrEmpty.filter(_.bias > 0f).filter(x => x.mode == Some("deboost") )
+
+    queryDeBoostedFields
       .map(field => BoostableCorrelators(field.name, field.values, Some(field.bias)))
       .distinct // de-dup and favor query fields
   }


### PR DESCRIPTION
This PR adds support to deboost fields in query using an additional (optional, non-breaking) parameter in the query : mode.

If not present or invalid, the old behavior is used. If set to deboost, the concerned field will be deboosted instead of boosted. See it as a "should not" in elasticsearch